### PR TITLE
Support GHC 9.4

### DIFF
--- a/data-functor-logistic.cabal
+++ b/data-functor-logistic.cabal
@@ -14,7 +14,7 @@ extra-source-files: CHANGELOG.md, README.md
 library
     exposed-modules:
         Data.Functor.Logistic
-    build-depends:    base >= 4.9 && <4.17, distributive
+    build-depends:    base >= 4.9 && <4.18, distributive
     default-language: Haskell2010
 
 source-repository head


### PR DESCRIPTION
This package seems to build okay with base 4.17 (GHC 9.4), so the bound can be raised.

This change can be released to Hackage via [metadata revision](https://hackage.haskell.org/package/data-functor-logistic/maintain).