### PR TITLE
Allow base-4.21 for GHC 9.12

### DIFF
--- a/data-functor-logistic.cabal
+++ b/data-functor-logistic.cabal
@@ -14,7 +14,7 @@ extra-source-files: CHANGELOG.md, README.md
 library
     exposed-modules:
         Data.Functor.Logistic
-    build-depends:    base >= 4.9 && <4.19, distributive
+    build-depends:    base >= 4.9 && <4.22, distributive
     default-language: Haskell2010
 
 source-repository head


### PR DESCRIPTION
As a Hackage trustee I made a matching revision: https://hackage.haskell.org/package/data-functor-logistic-0.0/revisions/